### PR TITLE
optimize map columns 2 properties code

### DIFF
--- a/src/main/java/org/apache/commons/dbutils/BeanProcessor.java
+++ b/src/main/java/org/apache/commons/dbutils/BeanProcessor.java
@@ -465,9 +465,6 @@ public class BeanProcessor {
 
         for (int col = 1; col <= cols; col++) {
             String columnName = rsmd.getColumnLabel(col);
-            if (null == columnName || 0 == columnName.length()) {
-              columnName = rsmd.getColumnName(col);
-            }
             String propertyName = columnToPropertyOverrides.get(columnName);
             if (propertyName == null) {
                 propertyName = columnName;


### PR DESCRIPTION
String getColumnLabel(int column) throws SQLException
Gets the designated column's suggested title for use in printouts and displays. The suggested title is usually specified by the SQL AS clause. If a SQL AS is not specified, the value returned from getColumnLabel will be the same as the value returned by the getColumnName method.       --from jdk1.6 javadoc