### PR TITLE
get generated keys from queryRunner.insertBatch

### DIFF
--- a/src/main/java/org/apache/commons/dbutils/handlers/ScalarListHandler
+++ b/src/main/java/org/apache/commons/dbutils/handlers/ScalarListHandler
@@ -1,0 +1,91 @@
+package org.apache.commons.dbutils.handlers;
+
+import org.apache.commons.dbutils.ResultSetHandler;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This class will be useful to get generated keys from the {@code queryRunner.insertBatch} operation.
+ * <br>
+ * <br>
+ * Eg:-
+ * <pre>
+ * ResultSetHandler&lt;List&lt;Long&gt;&gt; rsh = new ScalarListHandler&lt;Long&gt;();
+ * Object[][] params = {{"col1row1", "col2row1"}, {"col1row2", "col2row2"}};
+ * List&lt;Long&gt; ids = queryRunner.insertBatch("INSERT INTO testtable (col1, col2) VALUES (?,?)", rsh, params);
+ * </pre>
+ *
+ * @param <T> correct type to match column type
+ * @author visruth
+ */
+public class ScalarListHandler<T> implements ResultSetHandler<List<T>> {
+
+    /**
+     * The column number to retrieve.
+     */
+    private final int columnIndex;
+
+    /**
+     * The column name to retrieve.  Either columnName or columnIndex
+     * will be used but never both.
+     */
+    private final String columnName;
+
+    /**
+     * Creates a new instance of ScalarHandler.  The first column will
+     * be returned from <code>handle()</code>.
+     */
+    public ScalarListHandler() {
+        this(1, null);
+    }
+
+    /**
+     * Creates a new instance of ScalarHandler.
+     *
+     * @param columnIndex The index of the column to retrieve from the
+     *                    <code>ResultSet</code>.
+     */
+    public ScalarListHandler(int columnIndex) {
+        this(columnIndex, null);
+    }
+
+    /**
+     * Creates a new instance of ScalarHandler.
+     *
+     * @param columnName The name of the column to retrieve from the
+     *                   <code>ResultSet</code>.
+     */
+    public ScalarListHandler(String columnName) {
+        this(1, columnName);
+    }
+
+    /**
+     * Helper constructor
+     *
+     * @param columnIndex The index of the column to retrieve from the
+     *                    <code>ResultSet</code>.
+     * @param columnName  The name of the column to retrieve from the
+     *                    <code>ResultSet</code>.
+     */
+    private ScalarListHandler(int columnIndex, String columnName) {
+        this.columnIndex = columnIndex;
+        this.columnName = columnName;
+    }
+
+
+    public List<T> handle(ResultSet rs) throws SQLException {
+        List<T> list = new ArrayList<>();
+        while (rs.next()) {
+            if (this.columnName == null) {
+                list.add((T) rs.getObject(this.columnIndex));
+            } else {
+                list.add((T) rs.getObject(this.columnName));
+            }
+        }
+        return list;
+    }
+
+}

--- a/src/main/java/org/apache/commons/dbutils/handlers/ScalarListHandler
+++ b/src/main/java/org/apache/commons/dbutils/handlers/ScalarListHandler
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.commons.dbutils.handlers;
 
 import org.apache.commons.dbutils.ResultSetHandler;

--- a/src/main/java/org/apache/commons/dbutils/handlers/ScalarListHandler
+++ b/src/main/java/org/apache/commons/dbutils/handlers/ScalarListHandler
@@ -77,7 +77,7 @@ public class ScalarListHandler<T> implements ResultSetHandler<List<T>> {
 
 
     public List<T> handle(ResultSet rs) throws SQLException {
-        List<T> list = new ArrayList<>();
+        List<T> list = new ArrayList<T>();
         while (rs.next()) {
             if (this.columnName == null) {
                 list.add((T) rs.getObject(this.columnIndex));


### PR DESCRIPTION
This class will be useful to get generated keys from the queryRunner.insertBatch operation.

Eg:-
```
   ResultSetHandler<List<Long>> rsh = new ScalarListHandler<Long>();
   Object[][] params = {{"col1row1", "col2row1"}, {"col1row2", "col2row2"}};
   List<Long> ids = queryRunner.insertBatch("INSERT INTO testtable (col1, col2) VALUES (?,?)", rsh, params);
```
Here, the `ids` object contains the generated keys of inserted rows in the order of insertion.