### PR TITLE
Be generous on result column having spaces.

### DIFF
--- a/src/main/java/org/apache/commons/dbutils/GenerousBeanProcessor.java
+++ b/src/main/java/org/apache/commons/dbutils/GenerousBeanProcessor.java
@@ -52,7 +52,7 @@ public class GenerousBeanProcessor extends BeanProcessor {
                 columnName = rsmd.getColumnName(col);
             }
 
-            final String generousColumnName = columnName.replace("_", "");
+            final String generousColumnName = columnName.replace("_", "").replace(" ", "");
 
             for (int i = 0; i < props.length; i++) {
                 final String propName = props[i].getName();


### PR DESCRIPTION
Query of type (show create table) in MySQL returns result with column header having spaces (Create Table)
This should be mapped to createTable prop using generousName transformation.