### PR TITLE
BeanProcessor throw java.util.NoSuchElementException

### DIFF
--- a/src/main/java/org/apache/commons/dbutils/BeanProcessor.java
+++ b/src/main/java/org/apache/commons/dbutils/BeanProcessor.java
@@ -504,7 +504,7 @@ public class BeanProcessor {
      * index after optional type processing or {@code null} if the column
      * value was SQL NULL.
      */
-    protected Object processColumn(final ResultSet rs, final int index, final Class<?> propType)
+    protected synchronized Object processColumn(final ResultSet rs, final int index, final Class<?> propType)
         throws SQLException {
 
         Object retval = rs.getObject(index);


### PR DESCRIPTION
 columnHandlers function  is not thread safe； multi thread call same BeanProcessor instance processColumn function may generate "java.util.NoSuchElementException" exception。
please see detail  https://bugs.openjdk.org/browse/JDK-8230843 
