### PR TITLE
Update BeanProcessor.java

### DIFF
--- a/src/main/java/org/apache/commons/dbutils/BeanProcessor.java
+++ b/src/main/java/org/apache/commons/dbutils/BeanProcessor.java
@@ -80,10 +80,10 @@ public class BeanProcessor {
         PRIMITIVE_DEFAULTS.put(Character.TYPE, Character.valueOf((char) 0));
 
         // Use a ServiceLoader to find implementations
-        ServiceLoader.load(ColumnHandler.class).forEach(COLUMN_HANDLERS::add);
+        ServiceLoader.load(ColumnHandler.class, BeanProcessor.class.getClassLoader()).forEach(COLUMN_HANDLERS::add);
 
         // Use a ServiceLoader to find implementations
-        ServiceLoader.load(PropertyHandler.class).forEach(PROPERTY_HANDLERS::add);
+        ServiceLoader.load(PropertyHandler.class, BeanProcessor.class.getClassLoader()).forEach(PROPERTY_HANDLERS::add);
     }
 
     /**


### PR DESCRIPTION
Use classloadercontext in serviceloader. This allows for correct usage when calling this library from within a isolated ClassLoader. A similar change was done in slf4j : https://github.com/qos-ch/slf4j/commit/43a36303e5a2338c22ec9aad5b01a401034eb553