### PR TITLE
Improvement in the next() method of the ResultSetIterator.java class

### DIFF
--- a/src/main/java/org/apache/commons/dbutils/ResultSetIterator.java
+++ b/src/main/java/org/apache/commons/dbutils/ResultSetIterator.java
@@ -95,11 +95,15 @@ public class ResultSetIterator implements Iterator<Object[]> {
      * columns in the {@code ResultSet}.
      * @see java.util.Iterator#next()
      * @throws RuntimeException if an SQLException occurs.
+     * @throws NoSuchElementException if there are no more rows in the {@code ResultSet}.
      */
     @Override
     public Object[] next() {
         try {
-            return resultSet.next() ? this.convert.toArray(resultSet) : new Object[0];
+            if (!resultSet.next()) {
+                throw new NoSuchElementException("No more rows in the ResultSet");
+            }
+            return this.convert.toArray(resultSet);
         } catch (final SQLException e) {
             rethrow(e);
             return null;


### PR DESCRIPTION
I added an explicit check for resultSet.next(). If there are no more rows, a NoSuchElementException exception is thrown. And I also updated the documentation to include the behavior when there are no more rows in the ResultSet.